### PR TITLE
Fix inventory de-sync

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/mw/MWListener.java
+++ b/src/main/java/com/bergerkiller/bukkit/mw/MWListener.java
@@ -348,6 +348,7 @@ public class MWListener implements Listener {
     public void onPlayerChangedWorld(final PlayerChangedWorldEvent event) {
         WorldConfig.get(event.getFrom()).onPlayerLeft(event.getPlayer());
         WorldConfig.get(event.getPlayer()).onPlayerEnter(event.getPlayer());
+        event.getPlayer().updateInventory();
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)


### PR DESCRIPTION
Fixes inventory appearing empty to the player when switching between worlds that have shared inventories.
Ex. When going to the nether the players inventory appears empty.