### PR TITLE
Add CustomNPCs to loadbefore

### DIFF
--- a/src/main/java/plugin.yml
+++ b/src/main/java/plugin.yml
@@ -4,7 +4,7 @@ build: ${project.build.number}
 api-version: 1.13
 authors: [KamikazePlatypus, mg_1999, Friwi, bergerkiller, lenis0012, timstans, bubba1234119]
 softdepend: [BKCommonLib, Multiverse-Core, PlaceholderAPI]
-loadbefore: [CMI, dynmap, Citizens, MobArena, RegionForSale, CreativeGates, HeroStronghold]
+loadbefore: [CMI, dynmap, Citizens, MobArena, RegionForSale, CreativeGates, HeroStronghold, CustomNPCs]
 classdepend: [BetterPortals, MythicDungeons]
 metrics: true
 


### PR DESCRIPTION
This pr loads the plugin before my plugin, CustomNPCs,  which prevents issues with NPC initialization. This seems like it is working around the solution, when the plugin should load on startup, not post world. This can be achieved by putting `load: STARTUP` in the plugin.yml. This would probably take some testing with other dependencies, to ensure seamless integration.